### PR TITLE
Add -H to sudo_prefix

### DIFF
--- a/refabric/bootstrap.py
+++ b/refabric/bootstrap.py
@@ -36,7 +36,7 @@ def bootstrap():
         'merge_states': True,
         'prompt_hosts': True,
         'forward_agent': True,
-        'sudo_prefix': "sudo -S -E -p '%(sudo_prompt)s' SSH_AUTH_SOCK=$SSH_AUTH_SOCK",
+        'sudo_prefix': "sudo -S -E -H -p '%(sudo_prompt)s' SSH_AUTH_SOCK=$SSH_AUTH_SOCK",
     })
 
     # Create global blueprint tasks


### PR DESCRIPTION
Using sudo with -E will make it so that the HOME env var isn't set to
the correct user. Add an explicit -H to make sure sudo sets it properly.
