### PR TITLE
bootstrap: Set env.shell while bootstrapping refabric

### DIFF
--- a/refabric/bootstrap.py
+++ b/refabric/bootstrap.py
@@ -37,6 +37,7 @@ def bootstrap():
         'prompt_hosts': True,
         'forward_agent': True,
         'sudo_prefix': "sudo -S -E -H -p '%(sudo_prompt)s' SSH_AUTH_SOCK=$SSH_AUTH_SOCK",
+        'shell': '/bin/bash -c',
     })
 
     # Create global blueprint tasks


### PR DESCRIPTION
This solves an issue in newer Ubuntu versions where they always run
`mesg n` when you have a login shell, even though there is no TTY.
